### PR TITLE
Add http.rb instrumentation to NewRelic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # newrelic_httprb
-New Relic instrumentation for the http, the gem! (http.rb)
+
+New Relic instrumentation for http, the gem! (http.rb)
+
+## Requirements
+
+* [newrelic_rpm](newrelic/rpm)
+* [http.rb](httprb/http)
+
+## Install
+
+Just add the gem to your Gemfile
+
+For optional requires, use:
+
+```ruby
+require 'newrelic/httprb'
+```
+
+## License
+
+(The MIT License)
+
+Copyright (c) 2016 Tiago Sousa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs = ['lib', 'test']
+  t.test_files = FileList['test/*_test.rb']
+end
+
+desc "Run tests"
+task :default => :test

--- a/lib/newrelic/httprb.rb
+++ b/lib/newrelic/httprb.rb
@@ -1,0 +1,2 @@
+require 'newrelic_httprb/instrumentation'
+require 'newrelic_httprb/version'

--- a/lib/newrelic_httprb.rb
+++ b/lib/newrelic_httprb.rb
@@ -1,2 +1,0 @@
-require "newrelic_httprb/instrumentation"
-require "newrelic_httprb/version"

--- a/lib/newrelic_httprb.rb
+++ b/lib/newrelic_httprb.rb
@@ -1,0 +1,2 @@
+require "newrelic_httprb/instrumentation"
+require "newrelic_httprb/version"

--- a/lib/newrelic_httprb/instrumentation.rb
+++ b/lib/newrelic_httprb/instrumentation.rb
@@ -16,6 +16,7 @@ DependencyDetection.defer do
       def perform_with_newrelic_trace(request, options)
         wrapped_request = ::NewRelicHTTP::HTTPRequest.new(request)
 
+        response = nil
         ::NewRelic::Agent::CrossAppTracing.tl_trace_http_request(wrapped_request) do
           # RUBY-1244 Disable further tracing in request to avoid double
           # counting if connection wasn't started (which calls request again).

--- a/lib/newrelic_httprb/instrumentation.rb
+++ b/lib/newrelic_httprb/instrumentation.rb
@@ -8,7 +8,7 @@ DependencyDetection.defer do
   executes do
     ::NewRelic::Agent.logger.info 'Installing http.rb instrumentation'
     require 'new_relic/agent/cross_app_tracing'
-    require 'newrelic_http/wrappers'
+    require 'newrelic_httprb/wrappers'
   end
 
   executes do

--- a/lib/newrelic_httprb/instrumentation.rb
+++ b/lib/newrelic_httprb/instrumentation.rb
@@ -1,0 +1,33 @@
+DependencyDetection.defer do
+  named :http_rb
+
+  depends_on do
+    defined?(HTTP) && defined?(HTTP::Client)
+  end
+
+  executes do
+    ::NewRelic::Agent.logger.info 'Installing http.rb instrumentation'
+    require 'new_relic/agent/cross_app_tracing'
+    require 'newrelic_http/wrappers'
+  end
+
+  executes do
+    class HTTP::Client
+      def perform_with_newrelic_trace(request, options)
+        wrapped_request = ::NewRelicHTTP::HTTPRequest.new(request)
+
+        ::NewRelic::Agent::CrossAppTracing.tl_trace_http_request(wrapped_request) do
+          # RUBY-1244 Disable further tracing in request to avoid double
+          # counting if connection wasn't started (which calls request again).
+          response = perform_without_newrelic_trace(request, options)
+          ::NewRelicHTTP::HTTPResponse.new(response)
+        end
+
+        response
+      end
+
+      alias perform_without_newrelic_trace perform
+      alias perform perform_with_newrelic_trace
+    end
+  end
+end

--- a/lib/newrelic_httprb/instrumentation.rb
+++ b/lib/newrelic_httprb/instrumentation.rb
@@ -18,8 +18,6 @@ DependencyDetection.defer do
 
         response = nil
         ::NewRelic::Agent::CrossAppTracing.tl_trace_http_request(wrapped_request) do
-          # RUBY-1244 Disable further tracing in request to avoid double
-          # counting if connection wasn't started (which calls request again).
           response = perform_without_newrelic_trace(request, options)
           ::NewRelicHTTP::HTTPResponse.new(response)
         end

--- a/lib/newrelic_httprb/version.rb
+++ b/lib/newrelic_httprb/version.rb
@@ -1,0 +1,3 @@
+module NewRelicHTTP
+  VERSION = '0.0.1'
+end

--- a/lib/newrelic_httprb/wrappers.rb
+++ b/lib/newrelic_httprb/wrappers.rb
@@ -1,0 +1,51 @@
+module NewRelicHTTP
+  class HTTPResponse
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    def [](key)
+      response.headers.each do |k,v|
+        if key.downcase == k.downcase
+          return v
+        end
+      end
+      nil
+    end
+
+    def to_hash
+      response.headers
+    end
+  end
+
+  class HTTPRequest
+    attr_reader :request, :uri
+
+    def initialize(request)
+      @request = request
+      @uri = request.uri
+    end
+
+    def type
+      "http.rb"
+    end
+
+    def method
+      request.verb
+    end
+
+    def host
+      request.socket_host
+    end
+
+    def [](key)
+      request.headers[key]
+    end
+
+    def []=(key, value)
+      request.headers[key] = value
+    end
+  end
+end

--- a/lib/newrelic_httprb/wrappers.rb
+++ b/lib/newrelic_httprb/wrappers.rb
@@ -1,24 +1,5 @@
 module NewRelicHTTP
-  class HTTPResponse
-    attr_reader :response
-
-    def initialize(response)
-      @response = response
-    end
-
-    def [](key)
-      response.headers.each do |k,v|
-        if key.downcase == k.downcase
-          return v
-        end
-      end
-      nil
-    end
-
-    def to_hash
-      response.headers
-    end
-  end
+  HTTPResponse = NewRelic::Agent::HTTPClients::HTTPClientResponse
 
   class HTTPRequest
     attr_reader :request, :uri

--- a/lib/newrelic_httprb/wrappers.rb
+++ b/lib/newrelic_httprb/wrappers.rb
@@ -1,5 +1,20 @@
 module NewRelicHTTP
-  HTTPResponse = NewRelic::Agent::HTTPClients::HTTPClientResponse
+  class HTTPResponse
+    attr_reader :response
+
+    def initialize(response)
+      @response = response
+    end
+
+    def [](key)
+      _, value = response.headers.find { |k,_| key.downcase == k.downcase }
+      value unless value.nil?
+    end
+
+    def to_hash
+      response.headers
+    end
+  end
 
   class HTTPRequest
     attr_reader :request, :uri
@@ -13,12 +28,16 @@ module NewRelicHTTP
       "http.rb"
     end
 
-    def method
-      request.verb
+    def host
+      if hostname = self['host']
+        hostname.split(':').first
+      else
+        request.host
+      end
     end
 
-    def host
-      request.socket_host
+    def method
+      request.verb.upcase
     end
 
     def [](key)

--- a/newrelic_httprb.gemspec
+++ b/newrelic_httprb.gemspec
@@ -1,0 +1,20 @@
+require File.expand_path('../lib/newrelic_httprb/version', __FILE__)
+
+Gem::Specification.new do |gem|
+  gem.authors       = ["Tiago Sousa"]
+  gem.email         = ["tiago.joao@gmail.com"]
+  gem.description   = %q{New Relic instrumentation for http.rb}
+  gem.summary       = %q{New Relic instrumentation for http.rb}
+  gem.homepage      = "https://github.com/Talkdesk/newrelic_httprb"
+  gem.license       = "MIT"
+
+  gem.files         = Dir["{lib}/**/*.rb", "LICENSE", "*.md"]
+  gem.name          = "newrelic_httprb"
+  gem.require_paths = ["lib"]
+  gem.version       = NewRelicHTTP::VERSION
+  gem.add_dependency 'newrelic_rpm', '~> 3.11'
+  gem.add_dependency 'http'
+
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'test-unit'
+end

--- a/newrelic_httprb.gemspec
+++ b/newrelic_httprb.gemspec
@@ -8,10 +8,13 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/Talkdesk/newrelic_httprb"
   gem.license       = "MIT"
 
-  gem.files         = Dir["{lib}/**/*.rb", "LICENSE", "*.md"]
   gem.name          = "newrelic_httprb"
   gem.require_paths = ["lib"]
   gem.version       = NewRelicHTTP::VERSION
+
+  gem.files         = `git ls-files`.split($/)
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+
   gem.add_dependency 'newrelic_rpm', '~> 3.11'
   gem.add_dependency 'http'
 

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -1,0 +1,49 @@
+require "http"
+require "test/unit"
+require "newrelic_rpm"
+require "newrelic/httprb"
+
+class HTTPTest < Test::Unit::TestCase
+  include NewRelic::Agent::Instrumentation::ControllerInstrumentation
+
+  URL = "http://www.google.com/index.html"
+
+  def setup
+    NewRelic::Agent.manual_start
+    @engine = NewRelic::Agent.instance.stats_engine
+    @engine.clear_stats
+  end
+
+  def assert_metrics(*m)
+    m.each do |x|
+      assert @engine.get_stats_no_scope(x), "#{x} not in metrics"
+    end
+  end
+
+  def test_get
+    response = HTTP.get URL
+
+    assert_match /<head>/i, response.body
+    assert_metrics "External/all",
+                   "External/www.google.com/http.rb/GET",
+                   "External/allOther",
+                   "External/www.google.com/all"
+  end
+
+  def test_post
+    HTTP.post URL
+
+    assert_metrics "External/all",
+                   "External/www.google.com/http.rb/POST",
+                   "External/allOther",
+                   "External/www.google.com/all"
+  end
+
+  def test_ignore
+    NewRelic::Agent.disable_all_tracing do
+      HTTP.get URL
+    end
+
+    assert_empty @engine.to_h
+  end
+end


### PR DESCRIPTION
Since Talkdesk/contacts-api-ruby uses `HalClient` that depends on http.rb (the gem!) and this HTTP client is not supported by the official NewRelic RPM, this optional gem can be included in projects using the client (or in the gem itself) to add external services monitoring in NewRelic for our Contacts API service.
